### PR TITLE
Fix always "Device is migrating" for some lamps

### DIFF
--- a/capabilitymap.js
+++ b/capabilitymap.js
@@ -210,7 +210,9 @@ const mapProperty = function mapProperty(Z2MDevice) {
 			} else mapExposure(exp); // generic types (e.g. numeric or binary)
 		});
 	}
-	const caps = homeyCapabilities.filter((cap) => cap !== null);
+	const caps = homeyCapabilities
+		.filter((cap) => cap !== null)
+		.sort();
 	return { caps, capDetails };
 };
 

--- a/capabilitymap.js
+++ b/capabilitymap.js
@@ -179,19 +179,24 @@ const getExpMap = function mapExposure() {
 // map capabilities to Homey
 const mapProperty = function mapProperty(Z2MDevice) {
 	const homeyCapabilities = [];
+	function pushUniqueCapabilities(capVal) {
+		if (!homeyCapabilities.includes(capVal)) {
+			homeyCapabilities.push(capVal);
+		}
+	}
 	const capDetails = {};
 	const mapExposure = (exp) => {
 		// create exception for color lights
 		if (exp.property === 'color') {
-			homeyCapabilities.push('light_hue');
+			pushUniqueCapabilities('light_hue');
 			capDetails.light_hue = exp;
-			homeyCapabilities.push('light_saturation');
+			pushUniqueCapabilities('light_saturation');
 			capDetails.light_saturation = exp;
 		} else {
 			const mapFunc = capabilityMap[exp.property];
 			if (mapFunc) { 		//  included in Homey mapping
 				const capVal = mapFunc();
-				homeyCapabilities.push(capVal[0]);
+				pushUniqueCapabilities(capVal[0]);
 				capDetails[capVal[0]] = exp; // [exp.unit, exp.name, exp.values];
 			}
 		}


### PR DESCRIPTION
The Philips Hue lamp possesses the following capabilities:

- light_hue
- light_saturation

This makes a problem where the function (caps) has duplicates, making the lamp always show the status "Device is migrating."

This fix solves this problem, but there is still another problem that seems like a race condition: when I pick a color, Homey goes back to the CCT mode, while the lamp still shows some color. These problems are probably related.