### PR TITLE
Enable support for GreenPower devices

### DIFF
--- a/drivers/bridge/device.js
+++ b/drivers/bridge/device.js
@@ -222,7 +222,7 @@ class MyDevice extends Device {
 					// get device list
 					if (topic.includes(`${this.bridgeTopic}/devices`)) {
 						// console.log('device list was updated', info);
-						const devices = info.filter((device) => device.type === 'EndDevice' || device.type === 'Router');
+						const devices = info.filter((device) => device.type === 'EndDevice' || device.type === 'Router' || device.type === 'GreenPower');
 						this.devices = devices;
 						// console.dir(this.devices, { depth: null });
 						this.homey.emit('devicelistupdate', true);


### PR DESCRIPTION
I have tested [EnOcean PTM 216Z](https://www.zigbee2mqtt.io/devices/PTM_216Z.html) Philips Hue Friends device based on Zigbee Green Power, and it works without issues.