### PR TITLE
Fix the color mode for the colored lamps

### DIFF
--- a/capabilitymap.js
+++ b/capabilitymap.js
@@ -68,6 +68,7 @@ const capabilityMap = {
 	// : (val) => ['light_hue', val.hue], // { color: { x: Number(val), y: Number(val) } }
 	// : (val) => ['light_saturation', Number(val)],
 	color_temp: (val) => ['light_temperature', (Number(val) - 153) / 347, { color_temp: 153 + (Number(val) * 347) }],
+	color_mode: (val) => ['light_mode', val === 'xy' || val === 'hs' ? 'color' : 'temperature'],
 
 	// Standard Homey enum capabilities
 	// light_mode
@@ -192,6 +193,8 @@ const mapProperty = function mapProperty(Z2MDevice) {
 			capDetails.light_hue = exp;
 			pushUniqueCapabilities('light_saturation');
 			capDetails.light_saturation = exp;
+			pushUniqueCapabilities('light_mode');
+			capDetails.light_mode = exp;
 		} else {
 			const mapFunc = capabilityMap[exp.property];
 			if (mapFunc) { 		//  included in Homey mapping

--- a/drivers/device/device.js
+++ b/drivers/device/device.js
@@ -265,15 +265,26 @@ class MyDevice extends Device {
 
 	// special for color light
 	async dimHueSat(values, source) {
+		if (values?.light_mode === 'temperature') {
+			return;
+		}
 		this.log(`${this.getName()} dim/hue/set requested via ${source}`);
 		const hue = values.light_hue || this.getCapabilityValue('light_hue');
 		const sat = values.light_saturation || this.getCapabilityValue('light_saturation');
-		const dim = this.getCapabilityValue('dim');
-		const { r, g, b } = hsbToRgb(hue, sat, dim);
-		const payload = { color: { r, g, b } };
+		const payload = this.getColorPayload(hue, sat);
 		await this.bridge.client.publish(`${this.deviceTopic}/set`, JSON.stringify(payload));
 		this.log(`${JSON.stringify(payload)} sent by ${source}`);
 		return Promise.resolve(true);
+	}
+
+	getColorPayload(hue, sat) {
+		if (this.store.capDetails?.light_mode?.name === 'color_hs') {
+			return { color: { hue: 360 * hue, saturation: 100 * sat } };
+		} else {
+			const dim = this.getCapabilityValue('dim');
+			const { r, g, b } = hsbToRgb(hue, sat, dim);
+			return { color: { r, g, b } };
+		}
 	}
 
 	async checkChangedOrDeleted() {
@@ -315,7 +326,7 @@ class MyDevice extends Device {
 						Object.entries(info).forEach((entry) => {
 							// exception for color light
 							if (entry[0] === 'color' && this.getCapabilities().includes('light_hue')) {
-								if (Object.prototype.hasOwnProperty.call(entry[1], 'hue')) this.setCapability('light_hue', entry[1].hue / 100);
+								if (Object.prototype.hasOwnProperty.call(entry[1], 'hue')) this.setCapability('light_hue', entry[1].hue / 360);
 								if (Object.prototype.hasOwnProperty.call(entry[1], 'saturation')) this.setCapability('saturation', entry[1].saturation / 100);
 							} else {
 								const mapFunc = capabilityMap[entry[0]];
@@ -400,7 +411,7 @@ class MyDevice extends Device {
 
 			// add exception for color light
 			if (this.getCapabilities().includes('light_hue')) {
-				this.registerMultipleCapabilityListener(['light_hue', 'light_saturation'], (values) => {
+				this.registerMultipleCapabilityListener(['light_hue', 'light_saturation', 'light_mode'], (values) => {
 					this.dimHueSat(values, 'app').catch(this.error);
 				}, 500);
 			}


### PR DESCRIPTION
There was an issue with the color lamps, specifically the NOUS/Philips Hue models. When I switched to the color mode in Homey, it automatically changed to the temperature mode. In Z2M, there are read-only settings where I've added a mapping:

```
color_mode: (val) => ['light_mode', val === 'xy' || val === 'hs' ? 'color' : 'temperature'],
```

I'm not entirely certain this handles every scenario, but I've aimed to maintain logic for lamps that don't support this settings + switched to 'hs' payload if lamp support it.