### PR TITLE
fixed device topic match

### DIFF
--- a/drivers/Zigbee2MQTTDevice.js
+++ b/drivers/Zigbee2MQTTDevice.js
@@ -326,7 +326,7 @@ module.exports = class Zigbee2MQTTDevice extends Device {
 					if (message.toString() === '') return;
 					const info = JSON.parse(message);
 					// Map the incoming value to a capability or setting
-					if (topic.includes(this.deviceTopic)) {
+					if (topic == this.deviceTopic) {
 						// console.log(`${this.getName()} update:`, info);
 						// this.setAvailable();
 						Object.entries(info).forEach((entry) => {


### PR DESCRIPTION
Devices that have names that are substrings of other device names react to invalid events for example I have a light named “Office” and a blind named “Office blinds” and the office blinds also receive the office events, the fix is to replace a .includes if statement with a equals statements so that previously
 “bridge/office blinds”.contains(“bridge/office”) would have given a false positive and now with  “bridge/office blinds” == “bridge/office” it doesn't