### PR TITLE
added support for more ikea devices

### DIFF
--- a/capabilitymap.js
+++ b/capabilitymap.js
@@ -169,6 +169,7 @@ const classIconMap = {
 	'vibration sensor': ['sensor', 'vibration_sensor.svg'],
 	'pressure sensor': ['sensor', 'vibration_sensor.svg'],
 	'wireless switch': ['sensor', 'wireless_switch.svg'],
+	'dimmer switch': ['sensor', 'wireless_switch.svg'],
 	'on/off switch': ['sensor', 'wireless_switch.svg'],
 	motion: ['sensor', 'motion.svg'],
 	'wall switch module': ['button', 'wireless_switch.svg'],
@@ -186,6 +187,10 @@ const classIconMap = {
 	kadrilj: ['windowcoverings', 'window_coverings.svg'],
 	praktlysing: ['windowcoverings', 'window_coverings.svg'],
 	tredansen: ['windowcoverings', 'window_coverings.svg'],
+	parasol: ['sensor', 'contact.svg'],
+	'tradfri shortcut': ['button', 'wireless_switch.svg'],
+	rodret: ['button', 'wireless_switch.svg'],
+	somrig: ['button', 'wireless_switch.svg'],
 };
 
 // map capabilities to Homey


### PR DESCRIPTION
Added support for:
- Ikea PARASOLL door/window Sensor
https://www.zigbee2mqtt.io/devices/E2013.html
- Ikea TRADFRI shortcut button
https://www.zigbee2mqtt.io/devices/E1812.html
- Ikea RODRET wireless dimmer/power switch
https://www.zigbee2mqtt.io/devices/E2201.html
- Ikea SOMRIG shortcut button
https://www.zigbee2mqtt.io/devices/E2213.html

Fixed support for:
- Philips Hue dimmer switch, it was marked as class "light" because it matched the rule `dimmer: ['light', 'light.svg']`
https://www.zigbee2mqtt.io/devices/324131092621.html