### PR TITLE
Action event received trigger based on string match

### DIFF
--- a/.homeycompose/flow/triggers/action_event_received.json
+++ b/.homeycompose/flow/triggers/action_event_received.json
@@ -1,0 +1,29 @@
+{
+  "title": {
+    "en": "Action event received"
+  },
+  "titleFormatted": {
+    "en": "Action [[event]] received."
+  },
+  "hint": {
+    "en": "An action event matching given string was received."
+  },
+  "highlight": true,
+  "args": [
+    {
+      "type": "device",
+      "name": "device",
+      "filter": "driver_id=device|group&capabilities=action"
+    },
+    {
+      "type": "string",
+      "name": "event",
+      "title": {
+        "en": "event"
+      },
+      "placeholder": {
+        "en": "event_name"
+      }
+    }
+  ]
+}

--- a/.homeycompose/flow/triggers/action_event_received.json
+++ b/.homeycompose/flow/triggers/action_event_received.json
@@ -16,7 +16,7 @@
       "filter": "driver_id=device|group&capabilities=action"
     },
     {
-      "type": "string",
+      "type": "text",
       "name": "event",
       "title": {
         "en": "event"
@@ -24,6 +24,16 @@
       "placeholder": {
         "en": "event_name"
       }
+    }
+  ],
+  "tokens": [
+    {
+      "name": "action",
+      "type": "string",
+      "title": {
+        "en": "Action"
+      },
+      "example": "off"
     }
   ]
 }

--- a/app.js
+++ b/app.js
@@ -23,11 +23,11 @@ const Homey = require('homey');
 const { capabilityMap, getExpMap } = require('./capabilitymap');
 
 class MyApp extends Homey.App {
-
   async onInit() {
     try {
       this.registerFlowListeners();
       this.homey.setMaxListeners(100); // INCREASE LISTENERS
+      this.registerFlowTriggers();
       this.log('App has been initialized');
     } catch (error) {
       this.error(error);
@@ -76,6 +76,15 @@ class MyApp extends Homey.App {
     });
   }
 
+  registerFlowTriggers() {
+    // custom trgger cards
+    const action_event_received = this.homey.flow.getDeviceTriggerCard('action_event_received');
+    action_event_received.registerRunListener(async (args, state) => {
+      if (args.event !== state.event) return false;
+      this.log(`Device: ${args.device.getName()} - action_event_received ${state.event}`);
+      return true;
+    });
+  }
 }
 
 module.exports = MyApp;

--- a/app.js
+++ b/app.js
@@ -81,7 +81,6 @@ class MyApp extends Homey.App {
     const action_event_received = this.homey.flow.getDeviceTriggerCard('action_event_received');
     action_event_received.registerRunListener(async (args, state) => {
       if (args.event !== state.event) return false;
-      this.log(`Device: ${args.device.getName()} - action_event_received ${state.event}`);
       return true;
     });
   }


### PR DESCRIPTION
This should resolve #31 

Adds a custom trigger card "Action [event] received" and triggers a flow only when matching action event is received. This will help for high talking zigbee devices such Hue Dimmer and Hue Dial.

app.js:
- added registerFlowTriggers()  to support future custom trigger registration

Zigbee2MQTTDevice.js
- handleMessage() update for extra action triggers

Sorry for the formatting of .js files, Prettier seems to think better :)