### PR TITLE
New functions

### DIFF
--- a/.homeycompose/capabilities/restart_bridge.json
+++ b/.homeycompose/capabilities/restart_bridge.json
@@ -1,0 +1,20 @@
+{
+    "type": "boolean",
+    "title": {
+      "en": "Restart bridge",
+      "nl": "Bridge herstarten",
+      "da": "Genstart bro",
+      "de": "Brücke neu starten",
+      "es": "Reiniciar puente",
+      "fr": "Redémarrer le pont",
+      "it": "Riavvia il ponte",
+      "no": "Start broen på nytt",
+      "sv": "Starta om bron",
+      "pl": "Zrestartuj most",
+      "ru": "Перезапустить мост",
+      "ko": "브리지 재시작"
+    },
+    "getable": false,
+    "setable": true,
+    "uiComponent": "button"
+  }

--- a/.homeycompose/flow/actions/custom_payload_set.json
+++ b/.homeycompose/flow/actions/custom_payload_set.json
@@ -45,7 +45,7 @@
     {
       "type": "device",
       "name": "device",
-      "filter": "driver_id=device"
+      "filter": "driver_id=device|group"
     },
     {
       "name": "val",

--- a/.homeycompose/flow/actions/effect.json
+++ b/.homeycompose/flow/actions/effect.json
@@ -14,25 +14,25 @@
     "ko": "효과 설정"
   },
   "titleFormatted": {
-    "en": "Set Color Power On Behavior to [[val]]",
-    "nl": "Stel kleuraan inschakelgedrag in op [[val]]",
-    "da": "Indstil farve tændingsadfærd til [[val]]",
-    "de": "Farbeinschaltverhalten auf [[val]] einstellen",
-    "es": "Establecer comportamiento de encendido de color en [[val]]",
-    "fr": "Définir le comportement de mise sous tension sur [[val]]",
-    "it": "Imposta il comportamento all'accensione del colore su [[val]]",
-    "no": "Sett farge slåpåatferd til [[val]]",
-    "sv": "Ställ in färgströmsbeteende till [[val]]",
-    "pl": "Ustaw zachowanie włączenia koloru na [[val]]",
-    "ru": "Установить поведение включения цвета на [[val]]",
-    "ko": "전원 켤 때 색상 설정을 [[val]]으로 설정"
+    "en": "Set Effect to [[val]]",
+    "nl": "Stel Effect in op [[val]]",
+    "da": "Sæt Effekt til [[val]]",
+    "de": "Setze Effekt auf [[val]]",
+    "es": "Establecer Efecto a [[val]]",
+    "fr": "Définir l'effet sur [[val]]",
+    "it": "Imposta Effetto su [[val]]",
+    "no": "Sett Effekt til [[val]]",
+    "sv": "Sätt Effekt till [[val]]",
+    "pl": "Ustaw Efekt na [[val]]",
+    "ru": "Установить Эффект на [[val]]",
+    "ko": "효과를 [[val]]로 설정"
   },
   "highlight": true,
   "args": [
     {
       "type": "device",
       "name": "device",
-      "filter": "driver_id=device|group&capabilities=color_power_on_behavior"
+      "filter": "driver_id=device|group&capabilities=effect"
     },
     {
       "type": "dropdown",

--- a/app.json
+++ b/app.json
@@ -7366,6 +7366,26 @@
       "setable": true,
       "insights": false
     },
+    "restart_bridge": {
+      "type": "boolean",
+      "title": {
+        "en": "Restart bridge",
+        "nl": "Bridge herstarten",
+        "da": "Genstart bro",
+        "de": "Brücke neu starten",
+        "es": "Reiniciar puente",
+        "fr": "Redémarrer le pont",
+        "it": "Riavvia il ponte",
+        "no": "Start broen på nytt",
+        "sv": "Starta om bron",
+        "pl": "Zrestartuj most",
+        "ru": "Перезапустить мост",
+        "ko": "브리지 재시작"
+      },
+      "getable": false,
+      "setable": true,
+      "uiComponent": "button"
+    },
     "running_state": {
       "type": "string",
       "title": {

--- a/drivers/bridge/device.js
+++ b/drivers/bridge/device.js
@@ -380,6 +380,13 @@ module.exports = class Zigbee2MQTTBridge extends Device {
         this.joinOnOff(onoff, 'app').catch((error) => this.error(error));
       });
 
+      this.registerCapabilityListener('restart_bridge', async () => {
+        return this.restart(null, 'app').catch((error) => {
+            this.error(error);
+            throw error; 
+        });
+      });
+
       this.listenersSet = true;
       return Promise.resolve(true);
     } catch (error) {

--- a/drivers/bridge/driver.js
+++ b/drivers/bridge/driver.js
@@ -27,6 +27,7 @@ const setTimeoutPromise = util.promisify(setTimeout);
 
 const capabilities = [
   'allow_joining',
+  'restart_bridge',
   'allow_joining_timeout',
   'meter_mpm',
   'meter_joined_devices',


### PR DESCRIPTION
The payload is now not only filtered on device, but also on groups.

Effects now don't filter on on color_power_on_behaviour but instead on effects. This makes more sense for lights since there is no color_power_on_behaviour capability, but there is a effect capability. The options displayed in the effect.json match the options displayed in the device.

Also added a button to the bride so that it can be manually restarted.
