### PR TITLE
Patch offline devices

### DIFF
--- a/.homeycompose/flow/triggers/meter_offline_devices_changed.json
+++ b/.homeycompose/flow/triggers/meter_offline_devices_changed.json
@@ -23,7 +23,7 @@
   ],
   "tokens": [
     {
-      "name": "meter_unavailable_devices",
+      "name": "meter_offline_devices",
       "type": "number",
       "title": {
         "en": "Unavailable devices",

--- a/.homeycompose/flow/triggers/meter_offline_devices_changed.json
+++ b/.homeycompose/flow/triggers/meter_offline_devices_changed.json
@@ -1,6 +1,6 @@
 {
   "title": {
-    "en": "The number of unavailable devices changed",
+    "en": "The number of offline devices changed",
     "nl": "Het aantal niet-beschikbare apparaten is gewijzigd",
     "da": "Antallet af utilgængelige enheder er ændret",
     "de": "Die Anzahl der nicht verfügbaren Geräte hat sich geändert",
@@ -26,7 +26,7 @@
       "name": "meter_offline_devices",
       "type": "number",
       "title": {
-        "en": "Unavailable devices",
+        "en": "offline devices",
         "nl": "Niet-beschikbare apparaten",
         "da": "Utilgængelige enheder",
         "de": "Nicht verfügbare Geräte",

--- a/app.json
+++ b/app.json
@@ -1083,7 +1083,7 @@
       },
       {
         "title": {
-          "en": "The number of unavailable devices changed",
+          "en": "The number of offline devices changed",
           "nl": "Het aantal niet-beschikbare apparaten is gewijzigd",
           "da": "Antallet af utilgængelige enheder er ændret",
           "de": "Die Anzahl der nicht verfügbaren Geräte hat sich geändert",
@@ -1109,7 +1109,7 @@
             "name": "meter_offline_devices",
             "type": "number",
             "title": {
-              "en": "Unavailable devices",
+              "en": "offline devices",
               "nl": "Niet-beschikbare apparaten",
               "da": "Utilgængelige enheder",
               "de": "Nicht verfügbare Geräte",

--- a/app.json
+++ b/app.json
@@ -1106,7 +1106,7 @@
         ],
         "tokens": [
           {
-            "name": "meter_unavailable_devices",
+            "name": "meter_offline_devices",
             "type": "number",
             "title": {
               "en": "Unavailable devices",
@@ -1125,7 +1125,7 @@
             "example": 3
           }
         ],
-        "id": "meter_unavailable_devices_changed"
+        "id": "meter_offline_devices_changed"
       },
       {
         "title": {


### PR DESCRIPTION
Fixed a bug where the number of offline devices card would not work. Also changed "unavailable devices" to "offline devices" on the cards for consistency. 