### PR TITLE
Fix voltage handling

### DIFF
--- a/drivers/Zigbee2MQTTDevice.js
+++ b/drivers/Zigbee2MQTTDevice.js
@@ -373,7 +373,8 @@ module.exports = class Zigbee2MQTTDevice extends Device {
                 } else {
                   const mapFunc = capabilityMap[entry[0]];
                   if (mapFunc) { //  included in Homey mapping
-                    const capVal = mapFunc(entry[1]);
+                    const exp = Object.values(this.store.capDetails).find((item) => item.property === entry[0]);
+                    const capVal = mapFunc(entry[1], exp);
                     // Add extra triggers for ACTION
                     if (capVal[0] === 'action') {
                       // Action event received


### PR DESCRIPTION
Fix voltage handling in capabilityMap and update Zigbee2MQTTDevice ma…pping to use expose details. Voltage handling was breaked for "V" unit, because hasVoltage was not passed in Zigbee2MQTTDevice > connectBridge > handleMessage. This fix uses exposes unit instead of hasPower hack.