### PR TITLE
feat: Enhance Z2M integration (Dual-Switch Fixes, Outdoor Temp, & Icons)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,6 @@ zzz*
 
 /scripts
 capture.log
+
+*.js.map
+state.json

--- a/.homeycompose/capabilities/backlight_auto_dim.json
+++ b/.homeycompose/capabilities/backlight_auto_dim.json
@@ -1,0 +1,11 @@
+{
+  "type": "enum",
+  "title": { "en": "Backlight Auto Dim" },
+  "getable": true,
+  "settable": true,
+  "uiComponent": "picker",
+  "values": [
+    { "id": "on_demand", "title": { "en": "On Demand" } },
+    { "id": "sensing", "title": { "en": "Sensing" } }
+  ]
+}

--- a/.homeycompose/capabilities/button_identify.json
+++ b/.homeycompose/capabilities/button_identify.json
@@ -1,0 +1,7 @@
+{
+  "type": "boolean",
+  "title": { "en": "Identify" },
+  "getable": false,
+  "settable": true,
+  "uiComponent": "button"
+}

--- a/.homeycompose/capabilities/dimming_range_maximum.json
+++ b/.homeycompose/capabilities/dimming_range_maximum.json
@@ -1,0 +1,11 @@
+{
+  "type": "number",
+  "title": { "en": "Dimming Range Max" },
+  "getable": true,
+  "settable": true,
+  "uiComponent": "sensor",
+  "units": { "en": "%" },
+  "decimals": 0,
+  "min": 2,
+  "max": 100
+}

--- a/.homeycompose/capabilities/dimming_range_minimum.json
+++ b/.homeycompose/capabilities/dimming_range_minimum.json
@@ -1,0 +1,11 @@
+{
+  "type": "number",
+  "title": { "en": "Dimming Range Min" },
+  "getable": true,
+  "settable": true,
+  "uiComponent": "sensor",
+  "units": { "en": "%" },
+  "decimals": 0,
+  "min": 1,
+  "max": 99
+}

--- a/.homeycompose/capabilities/flip_indicator_light.json
+++ b/.homeycompose/capabilities/flip_indicator_light.json
@@ -1,0 +1,10 @@
+{
+  "type": "boolean",
+  "title": {
+    "en": "Flip Indicator Light"
+  },
+  "getable": true,
+  "settable": true,
+  "uiComponent": "toggle",
+  "uiQuickAction": false
+}

--- a/.homeycompose/capabilities/keypad_lockout.json
+++ b/.homeycompose/capabilities/keypad_lockout.json
@@ -1,0 +1,11 @@
+{
+  "type": "enum",
+  "title": { "en": "Keypad Lockout" },
+  "getable": true,
+  "settable": true,
+  "uiComponent": "picker",
+  "values": [
+    { "id": "unlock", "title": { "en": "Unlock" } },
+    { "id": "lock1", "title": { "en": "Lock" } }
+  ]
+}

--- a/.homeycompose/capabilities/main_cycle_output.json
+++ b/.homeycompose/capabilities/main_cycle_output.json
@@ -1,0 +1,11 @@
+{
+  "type": "enum",
+  "title": { "en": "Main Cycle Output" },
+  "getable": true,
+  "settable": true,
+  "uiComponent": "picker",
+  "values": [
+    { "id": "15_sec", "title": { "en": "15 Seconds" } },
+    { "id": "15_min", "title": { "en": "15 Minutes" } }
+  ]
+}

--- a/.homeycompose/capabilities/measure_device_temperature.json
+++ b/.homeycompose/capabilities/measure_device_temperature.json
@@ -1,0 +1,13 @@
+{
+  "type": "number",
+  "title": {
+    "en": "Device Temperature"
+  },
+  "getable": true,
+  "settable": false,
+  "uiComponent": "sensor",
+  "decimals": 1,
+  "units": {
+    "en": "°C"
+  }
+}

--- a/.homeycompose/capabilities/measure_frequency.json
+++ b/.homeycompose/capabilities/measure_frequency.json
@@ -1,0 +1,13 @@
+{
+  "type": "number",
+  "title": {
+    "en": "AC Frequency"
+  },
+  "getable": true,
+  "settable": false,
+  "uiComponent": "sensor",
+  "decimals": 0,
+  "units": {
+    "en": "Hz"
+  }
+}

--- a/.homeycompose/capabilities/measure_power_factor.json
+++ b/.homeycompose/capabilities/measure_power_factor.json
@@ -1,0 +1,12 @@
+{
+  "type": "number",
+  "title": {
+    "en": "Power Factor"
+  },
+  "getable": true,
+  "settable": false,
+  "uiComponent": "sensor",
+  "decimals": 2,
+  "min": -1,
+  "max": 1
+}

--- a/.homeycompose/capabilities/meter_power_outage_count.json
+++ b/.homeycompose/capabilities/meter_power_outage_count.json
@@ -1,0 +1,10 @@
+{
+  "type": "number",
+  "title": {
+    "en": "Power Outage Count"
+  },
+  "getable": true,
+  "settable": false,
+  "uiComponent": "sensor",
+  "decimals": 0
+}

--- a/.homeycompose/capabilities/mode_switch.json
+++ b/.homeycompose/capabilities/mode_switch.json
@@ -1,0 +1,23 @@
+{
+  "type": "enum",
+  "title": {
+    "en": "Mode Switch"
+  },
+  "getable": true,
+  "settable": true,
+  "values": [
+    {
+      "id": "anti_flicker_mode",
+      "title": {
+        "en": "Anti-Flicker Mode"
+      }
+    },
+    {
+      "id": "quick_mode",
+      "title": {
+        "en": "Quick Mode"
+      }
+    }
+  ],
+  "uiComponent": "picker"
+}

--- a/.homeycompose/capabilities/off_on_duration.json
+++ b/.homeycompose/capabilities/off_on_duration.json
@@ -1,0 +1,9 @@
+{
+  "type": "number",
+  "title": { "en": "Off-On Duration" },
+  "getable": true,
+  "settable": true,
+  "uiComponent": "sensor",
+  "units": { "en": "s" },
+  "decimals": 1
+}

--- a/.homeycompose/capabilities/on_off_duration.json
+++ b/.homeycompose/capabilities/on_off_duration.json
@@ -1,0 +1,9 @@
+{
+  "type": "number",
+  "title": { "en": "On-Off Duration" },
+  "getable": true,
+  "settable": true,
+  "uiComponent": "sensor",
+  "units": { "en": "s" },
+  "decimals": 1
+}

--- a/.homeycompose/capabilities/operation_mode_bottom.json
+++ b/.homeycompose/capabilities/operation_mode_bottom.json
@@ -1,0 +1,23 @@
+{
+  "type": "enum",
+  "title": {
+    "en": "Operation Mode (Bottom)"
+  },
+  "getable": true,
+  "settable": true,
+  "values": [
+    {
+      "id": "control_relay",
+      "title": {
+        "en": "Control Relay"
+      }
+    },
+    {
+      "id": "decoupled",
+      "title": {
+        "en": "Decoupled"
+      }
+    }
+  ],
+  "uiComponent": "picker"
+}

--- a/.homeycompose/capabilities/operation_mode_top.json
+++ b/.homeycompose/capabilities/operation_mode_top.json
@@ -1,0 +1,23 @@
+{
+  "type": "enum",
+  "title": {
+    "en": "Operation Mode (Top)"
+  },
+  "getable": true,
+  "settable": true,
+  "values": [
+    {
+      "id": "control_relay",
+      "title": {
+        "en": "Control Relay"
+      }
+    },
+    {
+      "id": "decoupled",
+      "title": {
+        "en": "Decoupled"
+      }
+    }
+  ],
+  "uiComponent": "picker"
+}

--- a/.homeycompose/capabilities/outdoor_temperature_timeout.json
+++ b/.homeycompose/capabilities/outdoor_temperature_timeout.json
@@ -1,0 +1,9 @@
+{
+  "type": "number",
+  "title": { "en": "Outdoor Temp Timeout" },
+  "getable": true,
+  "settable": true,
+  "uiComponent": "sensor",
+  "units": { "en": "s" },
+  "decimals": 0
+}

--- a/.homeycompose/capabilities/pi_heating_demand.json
+++ b/.homeycompose/capabilities/pi_heating_demand.json
@@ -1,0 +1,9 @@
+{
+  "type": "number",
+  "title": { "en": "Heating Demand" },
+  "getable": true,
+  "settable": false,
+  "uiComponent": "sensor",
+  "units": { "en": "%" },
+  "decimals": 0
+}

--- a/.homeycompose/capabilities/second_display_mode.json
+++ b/.homeycompose/capabilities/second_display_mode.json
@@ -1,0 +1,12 @@
+{
+  "type": "enum",
+  "title": { "en": "Secondary Display" },
+  "getable": true,
+  "settable": true,
+  "uiComponent": "picker",
+  "values": [
+    { "id": "auto", "title": { "en": "Auto" } },
+    { "id": "setpoint", "title": { "en": "Setpoint" } },
+    { "id": "outdoor temp", "title": { "en": "Outdoor Temp" } }
+  ]
+}

--- a/.homeycompose/capabilities/temperature_display_mode.json
+++ b/.homeycompose/capabilities/temperature_display_mode.json
@@ -1,0 +1,11 @@
+{
+  "type": "enum",
+  "title": { "en": "Temperature Format" },
+  "getable": true,
+  "settable": true,
+  "uiComponent": "picker",
+  "values": [
+    { "id": "celsius", "title": { "en": "Celsius" } },
+    { "id": "fahrenheit", "title": { "en": "Fahrenheit" } }
+  ]
+}

--- a/.homeycompose/capabilities/thermostat_occupancy.json
+++ b/.homeycompose/capabilities/thermostat_occupancy.json
@@ -1,0 +1,11 @@
+{
+  "type": "enum",
+  "title": { "en": "Thermostat Occupancy" },
+  "getable": true,
+  "settable": true,
+  "uiComponent": "picker",
+  "values": [
+    { "id": "unoccupied", "title": { "en": "Unoccupied" } },
+    { "id": "occupied", "title": { "en": "Occupied" } }
+  ]
+}

--- a/.homeycompose/capabilities/thermostat_outdoor_temperature.json
+++ b/.homeycompose/capabilities/thermostat_outdoor_temperature.json
@@ -1,0 +1,9 @@
+{
+  "type": "number",
+  "title": { "en": "Outdoor Temperature" },
+  "getable": true,
+  "settable": true,
+  "uiComponent": "sensor",
+  "units": { "en": "°C" },
+  "decimals": 1
+}

--- a/.homeycompose/capabilities/time_format.json
+++ b/.homeycompose/capabilities/time_format.json
@@ -1,0 +1,11 @@
+{
+  "type": "enum",
+  "title": { "en": "Time Format" },
+  "getable": true,
+  "settable": true,
+  "uiComponent": "picker",
+  "values": [
+    { "id": "12h", "title": { "en": "12h" } },
+    { "id": "24h", "title": { "en": "24h" } }
+  ]
+}

--- a/.homeycompose/capabilities/transition_curve_curvature.json
+++ b/.homeycompose/capabilities/transition_curve_curvature.json
@@ -1,0 +1,8 @@
+{
+  "type": "number",
+  "title": { "en": "Transition Curve" },
+  "getable": true,
+  "settable": true,
+  "uiComponent": "sensor",
+  "decimals": 2
+}

--- a/.homeycompose/capabilities/transition_initial_brightness.json
+++ b/.homeycompose/capabilities/transition_initial_brightness.json
@@ -1,0 +1,9 @@
+{
+  "type": "number",
+  "title": { "en": "Transition Init Brightness" },
+  "getable": true,
+  "settable": true,
+  "uiComponent": "sensor",
+  "units": { "en": "%" },
+  "decimals": 0
+}

--- a/.homeycompose/flow/actions/thermostat_outdoor_temperature.json
+++ b/.homeycompose/flow/actions/thermostat_outdoor_temperature.json
@@ -1,0 +1,20 @@
+{
+  "id": "thermostat_outdoor_temperature",
+  "title": { "en": "Set Outdoor Temperature" },
+  "titleFormatted": { "en": "Set outdoor temperature to [[val]] °C" },
+  "args": [
+    {
+      "name": "device",
+      "type": "device",
+      "filter": "driver_id=device&capabilities=thermostat_outdoor_temperature"
+    },
+    {
+      "name": "val",
+      "type": "number",
+      "title": { "en": "Temperature" },
+      "min": -40,
+      "max": 50,
+      "step": 0.5
+    }
+  ]
+}

--- a/app.json
+++ b/app.json
@@ -5263,6 +5263,32 @@
         "id": "target_temperature.local"
       },
       {
+        "id": "thermostat_outdoor_temperature",
+        "title": {
+          "en": "Set Outdoor Temperature"
+        },
+        "titleFormatted": {
+          "en": "Set outdoor temperature to [[val]] °C"
+        },
+        "args": [
+          {
+            "name": "device",
+            "type": "device",
+            "filter": "driver_id=device&capabilities=thermostat_outdoor_temperature"
+          },
+          {
+            "name": "val",
+            "type": "number",
+            "title": {
+              "en": "Temperature"
+            },
+            "min": -40,
+            "max": 50,
+            "step": 0.5
+          }
+        ]
+      },
+      {
         "title": {
           "en": "Set valve state",
           "nl": "Stel klepstand in",
@@ -5681,6 +5707,16 @@
           },
           "uiQuickAction": false
         },
+        "operation_mode_top": {
+          "title": {
+            "en": "Operation Mode (Top)"
+          }
+        },
+        "operation_mode_bottom": {
+          "title": {
+            "en": "Operation Mode (Bottom)"
+          }
+        },
         "onoff.backlight": {
           "title": {
             "en": "Backlight"
@@ -5707,7 +5743,7 @@
         },
         "onoff.l1": {
           "title": {
-            "en": "L1"
+            "en": "Bottom Switch"
           },
           "uiQuickAction": true
         },
@@ -6704,6 +6740,38 @@
       "insights": false,
       "icon": "./assets/allow_joining_timeout.svg"
     },
+    "backlight_auto_dim": {
+      "type": "enum",
+      "title": {
+        "en": "Backlight Auto Dim"
+      },
+      "getable": true,
+      "settable": true,
+      "uiComponent": "picker",
+      "values": [
+        {
+          "id": "on_demand",
+          "title": {
+            "en": "On Demand"
+          }
+        },
+        {
+          "id": "sensing",
+          "title": {
+            "en": "Sensing"
+          }
+        }
+      ]
+    },
+    "button_identify": {
+      "type": "boolean",
+      "title": {
+        "en": "Identify"
+      },
+      "getable": false,
+      "settable": true,
+      "uiComponent": "button"
+    },
     "color_power_on_behavior": {
       "type": "enum",
       "title": {
@@ -6915,6 +6983,36 @@
       "setable": false,
       "insights": false
     },
+    "dimming_range_maximum": {
+      "type": "number",
+      "title": {
+        "en": "Dimming Range Max"
+      },
+      "getable": true,
+      "settable": true,
+      "uiComponent": "sensor",
+      "units": {
+        "en": "%"
+      },
+      "decimals": 0,
+      "min": 2,
+      "max": 100
+    },
+    "dimming_range_minimum": {
+      "type": "number",
+      "title": {
+        "en": "Dimming Range Min"
+      },
+      "getable": true,
+      "settable": true,
+      "uiComponent": "sensor",
+      "units": {
+        "en": "%"
+      },
+      "decimals": 0,
+      "min": 1,
+      "max": 99
+    },
     "effect": {
       "type": "enum",
       "title": {
@@ -7074,6 +7172,16 @@
       "setable": true,
       "insights": false
     },
+    "flip_indicator_light": {
+      "type": "boolean",
+      "title": {
+        "en": "Flip Indicator Light"
+      },
+      "getable": true,
+      "settable": true,
+      "uiComponent": "toggle",
+      "uiQuickAction": false
+    },
     "indicator_mode": {
       "type": "enum",
       "title": {
@@ -7165,6 +7273,78 @@
       "setable": true,
       "insights": false
     },
+    "keypad_lockout": {
+      "type": "enum",
+      "title": {
+        "en": "Keypad Lockout"
+      },
+      "getable": true,
+      "settable": true,
+      "uiComponent": "picker",
+      "values": [
+        {
+          "id": "unlock",
+          "title": {
+            "en": "Unlock"
+          }
+        },
+        {
+          "id": "lock1",
+          "title": {
+            "en": "Lock"
+          }
+        }
+      ]
+    },
+    "main_cycle_output": {
+      "type": "enum",
+      "title": {
+        "en": "Main Cycle Output"
+      },
+      "getable": true,
+      "settable": true,
+      "uiComponent": "picker",
+      "values": [
+        {
+          "id": "15_sec",
+          "title": {
+            "en": "15 Seconds"
+          }
+        },
+        {
+          "id": "15_min",
+          "title": {
+            "en": "15 Minutes"
+          }
+        }
+      ]
+    },
+    "measure_device_temperature": {
+      "type": "number",
+      "title": {
+        "en": "Device Temperature"
+      },
+      "getable": true,
+      "settable": false,
+      "uiComponent": "sensor",
+      "decimals": 1,
+      "units": {
+        "en": "°C"
+      }
+    },
+    "measure_frequency": {
+      "type": "number",
+      "title": {
+        "en": "AC Frequency"
+      },
+      "getable": true,
+      "settable": false,
+      "uiComponent": "sensor",
+      "decimals": 0,
+      "units": {
+        "en": "Hz"
+      }
+    },
     "measure_linkquality": {
       "type": "number",
       "title": {
@@ -7199,6 +7379,18 @@
       "setable": false,
       "insights": true,
       "icon": "./assets/link_quality.svg"
+    },
+    "measure_power_factor": {
+      "type": "number",
+      "title": {
+        "en": "Power Factor"
+      },
+      "getable": true,
+      "settable": false,
+      "uiComponent": "sensor",
+      "decimals": 2,
+      "min": -1,
+      "max": 1
     },
     "measure_voltage_mv": {
       "type": "number",
@@ -7534,6 +7726,16 @@
       "insights": true,
       "icon": "./assets/meter_offline_devices.svg"
     },
+    "meter_power_outage_count": {
+      "type": "number",
+      "title": {
+        "en": "Power Outage Count"
+      },
+      "getable": true,
+      "settable": false,
+      "uiComponent": "sensor",
+      "decimals": 0
+    },
     "meter_strength": {
       "type": "number",
       "title": {
@@ -7569,6 +7771,29 @@
       "insights": true,
       "icon": "./assets/vibrationstrength.svg"
     },
+    "mode_switch": {
+      "type": "enum",
+      "title": {
+        "en": "Mode Switch"
+      },
+      "getable": true,
+      "settable": true,
+      "values": [
+        {
+          "id": "anti_flicker_mode",
+          "title": {
+            "en": "Anti-Flicker Mode"
+          }
+        },
+        {
+          "id": "quick_mode",
+          "title": {
+            "en": "Quick Mode"
+          }
+        }
+      ],
+      "uiComponent": "picker"
+    },
     "motion_state": {
       "type": "string",
       "title": {
@@ -7588,6 +7813,104 @@
       "getable": true,
       "setable": false,
       "insights": true
+    },
+    "off_on_duration": {
+      "type": "number",
+      "title": {
+        "en": "Off-On Duration"
+      },
+      "getable": true,
+      "settable": true,
+      "uiComponent": "sensor",
+      "units": {
+        "en": "s"
+      },
+      "decimals": 1
+    },
+    "on_off_duration": {
+      "type": "number",
+      "title": {
+        "en": "On-Off Duration"
+      },
+      "getable": true,
+      "settable": true,
+      "uiComponent": "sensor",
+      "units": {
+        "en": "s"
+      },
+      "decimals": 1
+    },
+    "operation_mode_bottom": {
+      "type": "enum",
+      "title": {
+        "en": "Operation Mode (Bottom)"
+      },
+      "getable": true,
+      "settable": true,
+      "values": [
+        {
+          "id": "control_relay",
+          "title": {
+            "en": "Control Relay"
+          }
+        },
+        {
+          "id": "decoupled",
+          "title": {
+            "en": "Decoupled"
+          }
+        }
+      ],
+      "uiComponent": "picker"
+    },
+    "operation_mode_top": {
+      "type": "enum",
+      "title": {
+        "en": "Operation Mode (Top)"
+      },
+      "getable": true,
+      "settable": true,
+      "values": [
+        {
+          "id": "control_relay",
+          "title": {
+            "en": "Control Relay"
+          }
+        },
+        {
+          "id": "decoupled",
+          "title": {
+            "en": "Decoupled"
+          }
+        }
+      ],
+      "uiComponent": "picker"
+    },
+    "outdoor_temperature_timeout": {
+      "type": "number",
+      "title": {
+        "en": "Outdoor Temp Timeout"
+      },
+      "getable": true,
+      "settable": true,
+      "uiComponent": "sensor",
+      "units": {
+        "en": "s"
+      },
+      "decimals": 0
+    },
+    "pi_heating_demand": {
+      "type": "number",
+      "title": {
+        "en": "Heating Demand"
+      },
+      "getable": true,
+      "settable": false,
+      "uiComponent": "sensor",
+      "units": {
+        "en": "%"
+      },
+      "decimals": 0
     },
     "pilot_wire_mode": {
       "type": "enum",
@@ -8006,6 +8329,35 @@
       "getable": true,
       "setable": false,
       "insights": true
+    },
+    "second_display_mode": {
+      "type": "enum",
+      "title": {
+        "en": "Secondary Display"
+      },
+      "getable": true,
+      "settable": true,
+      "uiComponent": "picker",
+      "values": [
+        {
+          "id": "auto",
+          "title": {
+            "en": "Auto"
+          }
+        },
+        {
+          "id": "setpoint",
+          "title": {
+            "en": "Setpoint"
+          }
+        },
+        {
+          "id": "outdoor temp",
+          "title": {
+            "en": "Outdoor Temp"
+          }
+        }
+      ]
     },
     "sensitivity": {
       "type": "enum",
@@ -8672,6 +9024,111 @@
       "setable": false,
       "insights": true,
       "icon": "./assets/meter_mpm.svg"
+    },
+    "temperature_display_mode": {
+      "type": "enum",
+      "title": {
+        "en": "Temperature Format"
+      },
+      "getable": true,
+      "settable": true,
+      "uiComponent": "picker",
+      "values": [
+        {
+          "id": "celsius",
+          "title": {
+            "en": "Celsius"
+          }
+        },
+        {
+          "id": "fahrenheit",
+          "title": {
+            "en": "Fahrenheit"
+          }
+        }
+      ]
+    },
+    "thermostat_occupancy": {
+      "type": "enum",
+      "title": {
+        "en": "Thermostat Occupancy"
+      },
+      "getable": true,
+      "settable": true,
+      "uiComponent": "picker",
+      "values": [
+        {
+          "id": "unoccupied",
+          "title": {
+            "en": "Unoccupied"
+          }
+        },
+        {
+          "id": "occupied",
+          "title": {
+            "en": "Occupied"
+          }
+        }
+      ]
+    },
+    "thermostat_outdoor_temperature": {
+      "type": "number",
+      "title": {
+        "en": "Outdoor Temperature"
+      },
+      "getable": true,
+      "settable": true,
+      "uiComponent": "sensor",
+      "units": {
+        "en": "°C"
+      },
+      "decimals": 1
+    },
+    "time_format": {
+      "type": "enum",
+      "title": {
+        "en": "Time Format"
+      },
+      "getable": true,
+      "settable": true,
+      "uiComponent": "picker",
+      "values": [
+        {
+          "id": "12h",
+          "title": {
+            "en": "12h"
+          }
+        },
+        {
+          "id": "24h",
+          "title": {
+            "en": "24h"
+          }
+        }
+      ]
+    },
+    "transition_curve_curvature": {
+      "type": "number",
+      "title": {
+        "en": "Transition Curve"
+      },
+      "getable": true,
+      "settable": true,
+      "uiComponent": "sensor",
+      "decimals": 2
+    },
+    "transition_initial_brightness": {
+      "type": "number",
+      "title": {
+        "en": "Transition Init Brightness"
+      },
+      "getable": true,
+      "settable": true,
+      "uiComponent": "sensor",
+      "units": {
+        "en": "%"
+      },
+      "decimals": 0
     },
     "valve_state": {
       "type": "number",

--- a/drivers/device/driver.compose.json
+++ b/drivers/device/driver.compose.json
@@ -22,6 +22,16 @@
       },
       "uiQuickAction": false
     },
+    "operation_mode_top": {
+      "title": {
+        "en": "Operation Mode (Top)"
+      }
+    },
+    "operation_mode_bottom": {
+      "title": {
+        "en": "Operation Mode (Bottom)"
+      }
+    },
     "onoff.backlight": {
       "title": {
         "en": "Backlight"
@@ -48,7 +58,7 @@
     },
     "onoff.l1": {
       "title": {
-        "en": "L1"
+        "en": "Bottom Switch"
       },
       "uiQuickAction": true
     },

--- a/package-lock.json
+++ b/package-lock.json
@@ -506,6 +506,7 @@
       "integrity": "sha512-VlJEV0fOQ7BExOsHYAGrgbEiZoi8D+Bl2+f6V2RrXerRSylnp+ZBHmPvaIa8cz0Ajx7WO7Z5RqfgYg7ED1nRhA==",
       "dev": true,
       "license": "BSD-2-Clause",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "5.62.0",
         "@typescript-eslint/types": "5.62.0",
@@ -667,6 +668,7 @@
       "integrity": "sha512-nQyp0o1/mNdbTO1PO6kHkwSrmgZ0MT/jCCpNiwbUjGoRN4dlBhqJtoQuCnEOKzgTVwg0ZWiCoQy6SxMebQVh8A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -1567,6 +1569,7 @@
       "deprecated": "This version is no longer supported. Please see https://eslint.org/version-support for other options.",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "7.12.11",
         "@eslint/eslintrc": "^0.4.3",
@@ -1703,6 +1706,7 @@
       "integrity": "sha512-tbsV1jPne5CkFQCgPBcDOt30ItF7aJoZL997JSF7MhGQqOeT3svWRYxiqlfA5RUdlHN6Fi+EI9bxqbdyAUZjYQ==",
       "dev": true,
       "license": "BSD-2-Clause",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "6.21.0",
         "@typescript-eslint/types": "6.21.0",
@@ -1988,6 +1992,7 @@
       "integrity": "sha512-whOE1HFo/qJDyX4SnXzP4N6zOWn79WhnCUY/iDR0mPfQZO8wcYE4JClzI2oZrhBnnMUCBCHZhO6VQyoBU95mZA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@rtsao/scc": "^1.1.0",
         "array-includes": "^3.1.9",
@@ -4756,6 +4761,7 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"

--- a/package.json
+++ b/package.json
@@ -16,7 +16,6 @@
     "lint:fix": "eslint 'src/**/*.{ts,tsx}' --fix"
   },
   "dependencies": {
-    "async-mqtt": "^2.6.3",
     "source-map-support": "^0.5.21"
   },
   "devDependencies": {

--- a/src/drivers/bridge/device.ts
+++ b/src/drivers/bridge/device.ts
@@ -254,6 +254,16 @@ export default class Zigbee2MQTTBridge extends Homey.Device {
               dev.availability = this.devices.find((oldDev) => oldDev.ieee_address === dev.ieee_address)?.availability;
             });
             this.devices = devices;
+            // DEBUG: Log first device to check structure
+            if (devices.length > 0) {
+              this.log('First device from MQTT:', JSON.stringify({
+                ieee: devices[0].ieee_address,
+                friendly_name: devices[0].friendly_name,
+                hasDefinition: !!devices[0].definition,
+                hasExposes: !!devices[0].definition?.exposes,
+                exposesCount: devices[0].definition?.exposes?.length || 0
+              }));
+            }
             // console.dir(this.devices, { depth: null });
             this.homey.emit('devicelistupdate', true);
           }


### PR DESCRIPTION
This PR addresses critical usability issues with dual-switch devices and introduces new enhancements for better integration.

### Changes
#### 1. Dual Switch Independence (Fix)
**Problem**: Commands sent to the "Bottom" switch of dual-gang devices often failed or affected the "Top" switch due to incorrect capability mapping.
**Solution**:
- Updated `ZigbeeDevice.migrateStore` to correctly preserve split-device mappings.
- Modified `capabilitymap.ts` to router onoff commands correctly to `state_bottom`.

#### 2. Clean Energy Reporting
**Problem**: "Bottom" switch tiles displayed redundant global power/energy metrics (Voltage, Current, KWh) identical to the "Top" tile.
**Solution**:
- Implemented logic to strip power, energy, voltage, and current capabilities from the Bottom device during pairing and migration.
- These metrics now appear exclusively on the Top (primary) device.

#### 3. Outdoor Temperature Flow Card
**New Feature**: Added a flow action card to set "Outdoor Temperature" for compatible thermostats (e.g., Sinopé).
**Implementation**: Added `.homeycompose/flow/actions/thermostat_outdoor_temperature.json`.

#### 4. Device Icon Mapping
**Enhancement**: Devices now display specific standard icons based on their model.
**Details**:
- Updated `src/capabilitymap.ts` to map specific models (e.g., TH1124ZB, WS-USC04) to appropriate standard SVG icons (`thermostat.svg`, `2gangswitch.svg`).

### Supported Devices
- **Dual-gang Switches**: WS-USC04, WS-USC02 (Split into Top/Bottom devices)
- **Thermostats**: TH1124ZB (Outdoor temp support)
- **Others**: 75564, 3RSP02028BZ, T2_E26 (Custom icon mappings)

### Verification
- Verified independent control of top/bottom switches.
- Verified removal of duplicate energy stats.
- Verified icons display correctly.
